### PR TITLE
Calculate breadcrumb widths based on text when breadcrumb.w=0

### DIFF
--- a/R/sunburst.R
+++ b/R/sunburst.R
@@ -17,7 +17,8 @@
 #' @param breadcrumb,legend \code{list} to customize the breadcrumb trail or legend.  This argument
 #'          should be in the form \code{list(w =, h =, s =, t = )} where
 #'          \code{w} is the width, \code{h} is the height, \code{s} is the spacing,
-#'          and \code{t} is the tail all in \code{px}.
+#'          and \code{t} is the tail all in \code{px}. Set \code{w} to \code{0} for
+#'          breadcrumbs widths based on text length.
 #' @param sortFunction \code{\link[htmlwidgets]{JS}} function to sort the slices.
 #'          The default sort is by size.
 #'

--- a/inst/htmlwidgets/sunburst.js
+++ b/inst/htmlwidgets/sunburst.js
@@ -304,7 +304,7 @@ HTMLWidgets.widget({
           curr_breadcrumb_x += nodeArray[k-1].string_length;
           nodeArray[k].breadcrumb_h = nodeArray[k-1].breadcrumb_h;
 
-          if (curr_breadcrumb_x + my_string_length > $("svg").width()*0.99) {
+          if (curr_breadcrumb_x + my_string_length > width*0.99) {
             nodeArray[k].breadcrumb_h += b.h;  // got to next line
             curr_breadcrumb_x = b.t + b.s;     // restart counter
           }

--- a/man/sunburst.Rd
+++ b/man/sunburst.Rd
@@ -31,7 +31,8 @@ of the sunburst.  Note, this will override \code{percent} and \code{count}.}
 \item{breadcrumb, legend}{\code{list} to customize the breadcrumb trail or legend.  This argument
 should be in the form \code{list(w =, h =, s =, t = )} where
 \code{w} is the width, \code{h} is the height, \code{s} is the spacing,
-and \code{t} is the tail all in \code{px}.}
+and \code{t} is the tail all in \code{px}. Set \code{w} to \code{0} for
+breadcrumbs widths based on text length.}
 
 \item{sortFunction}{\code{\link[htmlwidgets]{JS}} function to sort the slices.
 The default sort is by size.}
@@ -59,6 +60,8 @@ sunburst(sequences)
 sunburst(
   sequences
   ,count = TRUE
+  , breadcrumb=list(w=0, h=10,s=2,t=2)
+  , legend=list(w=200, h=20, s=3, r=3)
 )
 
 sunburst(
@@ -147,5 +150,6 @@ ngrams2 \%>>\%
   ) \%>>\%
   tagList \%>>\%
   browsable
+
 }
 


### PR DESCRIPTION
When the option breadcrumb is given with a 'w' <= 0, then the
lengths of the breadcrumbs are calculated based on the text
lengths. Furthermore, the breadcrumb is continued in the next line
if it is too long for the current.

Demonstration:
![image](https://cloud.githubusercontent.com/assets/516060/15132105/1dcfa4d8-1624-11e6-81ff-4c89484a654b.png)

Update: Demo code

```
sequences <- read.csv(
  system.file("examples/visit-sequences.csv",package="sunburstR"), header=F
  ,stringsAsFactors = FALSE
)
sequences <- sequences[sample(nrow(sequences),1000),]
sequences[,1] <- gsub("home","my home and my castle", sequences[,1])

sunburst(sequences,
             , breadcrumb=list(w=0, h=20,s=3,t=10)
             , legend=list(w=200, h=20, s=3, r=3)
)

```