### PR TITLE
Add more robust color

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: sunburstR
 Type: Package
 Title: htmlwidget for Kerry Rodden d3.js sequence sunburst
-Version: 0.3.1
-Date: 2016-05-24
+Version: 0.4.0
+Date: 2016-06-10
 Authors@R: c(
       person(
         "Mike", "Bostock"

--- a/R/sunburst.R
+++ b/R/sunburst.R
@@ -9,7 +9,8 @@
 #'          If legendOrder is not provided, then the legend will be in the descending
 #'          order of the top level hierarchy.
 #' @param colors \code{vector} of strings representing colors as hexadecimal for
-#'          manual colors.
+#'          manual colors.  If you want precise control of colors, supply a \code{list}
+#'          with \code{range} and/or \code{domain}.
 #' @param percent \code{logical} to include percentage of total in the explanation.
 #' @param count \code{logical} to include count and total in the explanation.
 #' @param explanation JavaScript function to define a custom explanation for the center

--- a/inst/htmlwidgets/sunburst.js
+++ b/inst/htmlwidgets/sunburst.js
@@ -8,7 +8,7 @@ HTMLWidgets.widget({
 
     var instance = {};
 
-    var draw = function() {
+    var draw = function(el, instance) {
 
       // would be much nicer to implement transitions/animation
       // remove previous in case of Shiny/dynamic
@@ -135,7 +135,7 @@ HTMLWidgets.widget({
         drawLegend();
         d3.select(el).select(".sunburst-togglelegend").on("click", toggleLegend);
 
-       };
+       }
 
       // Fade all but the current sequence, and show it in the breadcrumb trail.
       function mouseover(d) {
@@ -514,13 +514,13 @@ HTMLWidgets.widget({
         }
         instance.json = json;
 
-        draw();
+        draw(el, instance);
 
       },
 
       resize: function(width, height) {
 
-        draw();
+        draw(el, instance);
 
       },
 

--- a/inst/htmlwidgets/sunburst.js
+++ b/inst/htmlwidgets/sunburst.js
@@ -51,10 +51,35 @@ HTMLWidgets.widget({
       var colors = d3.scale.category20();
 
       if(x.options.colors !== null){
-        try{
-          colors.range(x.options.colors)
-        } catch(e) {
+        // if an array then we assume the colors
+        //  represent an array of hexadecimal colors to be used
+        if(Array.isArray(x.options.colors)) {
+          try{
+            colors.range(x.options.colors)
+          } catch(e) {
 
+          }
+        }
+
+        // if an object with range then we assume
+        //  that this is an array of colors to be used as range
+        if(x.options.colors.range){
+          try{
+            colors.domain(x.options.colors.domain)
+          } catch(e) {
+
+          }
+        }
+
+        // if an object with domain then we assume
+        //  that this is an array of colors to be used as domain
+        //  for more precise control of the colors assigned
+        if(x.options.colors.domain){
+          try{
+            colors.domain(x.options.colors.domain);
+          } catch(e) {
+
+          }
         }
       }
       // Total size of all segments; we set this later, after loading the data.

--- a/man/sunburst.Rd
+++ b/man/sunburst.Rd
@@ -19,7 +19,8 @@ If legendOrder is not provided, then the legend will be in the descending
 order of the top level hierarchy.}
 
 \item{colors}{\code{vector} of strings representing colors as hexadecimal for
-manual colors.}
+manual colors.  If you want precise control of colors, supply a \code{list}
+with \code{range} and/or \code{domain}.}
 
 \item{percent}{\code{logical} to include percentage of total in the explanation.}
 


### PR DESCRIPTION
As discussed in #17, when using multiple `sunburst` on a single page, a user might want to coordinate colors.  This pull provides the ability to specify both the `domain` and `range` of the color scale from `R`.

Using the reproducible example in #17, here is how we might use this new color functionality.

```
library(sunburstR)
library(RColorBrewer)
library(dplyr)
# reproducible problem
df <- data.frame(date = rep(seq(Sys.Date(), length = 2, by = '1 day'), each = 10))
df$relationships <- unlist(
  lapply(1:2, function(i){
    unlist(
      lapply(1:10, function(ii){
        paste0(sample(letters[1:10], sample(3:5, 1), replace = FALSE), collapse = '-')
      })
    )
  })
)
df <- split(df, df$date)
df <- do.call(
  rbind,
  lapply(df, function(x){
    n = round(runif(nrow(x), min = 1, max = 100))
    x$n <- (n/sum(n))*100
    x
  })
)
rownames(df) <- NULL

legend_items <- unique(unlist(strsplit(df$relationships, '-')))
cols <- sample(colorRampPalette(brewer.pal(12, 'Set3'))(length(legend_items)))

# plot each date
plt_fun <- function(flt_date){
  # filter for dt
  plt_df <- df %>%
    filter(date == flt_date) %>%
    select(-date)
  
  sunburst(
    plt_df,
    #  colors can now also accept a list
    #   specifying range and/or domain of the color scale
    colors = list(
      range=cols,
      domain=legend_items
    ),
    legendOrder=legend_items,
    width="100%"
  )
}

library(htmltools)
browsable(
  tagList(
    lapply(
      1:2,
      function(n){
        tags$div(
          style="width:48%; float:left;",
          plt_fun(unique(df$date)[n])
        )
      }
    )
  )
)
```