### PR TITLE
Added option to let percentage and counts display relative to parent element

### DIFF
--- a/R/sunburst.R
+++ b/R/sunburst.R
@@ -20,6 +20,8 @@
 #' @param valueField \code{character} for the field to use to calculate size.  The default
 #'          value is \code{"size"}.
 #' @param percent \code{logical} to include percentage of total in the explanation.
+#' @param percentMode \code{character} to determine if included percentage and count is of
+#'        the total or the parent element.
 #' @param count \code{logical} to include count and total in the explanation.
 #' @param explanation JavaScript function to define a custom explanation for the center
 #'          of the sunburst.  Note, this will override \code{percent} and \code{count}.
@@ -63,6 +65,7 @@ sunburst <- function(
   , colors = NULL
   , valueField = "size"
   , percent = TRUE
+  , percentMode = c("total", "parent")
   , count =  FALSE
   , explanation = NULL
   , breadcrumb = list()
@@ -84,6 +87,7 @@ sunburst <- function(
   }
   if(is.null(data) && !is.null(csvdata)) data <- csvdata
   if(is.null(data) && !is.null(jsondata)) data <- jsondata
+  percentMode <- match.arg(percentMode);
 
   # accept JSON string as data
   if( inherits(data,c("character","connection")) ){
@@ -121,6 +125,7 @@ sunburst <- function(
       ,colors = colors
       ,valueField = valueField
       ,percent = percent
+      ,percentMode = percentMode
       ,count = count
       ,explanation = explanation
       ,breadcrumb = breadcrumb

--- a/inst/htmlwidgets/sunburst.js
+++ b/inst/htmlwidgets/sunburst.js
@@ -173,6 +173,8 @@ function draw (el, instance, dispatch_) {
       );
     }
 
+    // if displaying values relative to parents then add percentage of parent
+    // and parent size properties into each node
     if (x.options.percentMode === "parent") {
       totalSize = root.value;
       root.percent = 100;
@@ -233,12 +235,15 @@ function draw (el, instance, dispatch_) {
   // Fade all but the current sequence, and show it in the breadcrumb trail.
   function mouseover(d) {
 
+    // calculate percentage in terms of total
+    // it should always make sense to show this percentage in the breadcrumb
     var percentageTotal = (100 * d.value / totalSize).toPrecision(3);
     var percentageTotalString = percentageTotal + "%";
     if (percentageTotal < 0.1) {
       percentageTotalString = "< 0.1%";
     }
 
+    // calculate percentage depending on mode, could be of total or of parent element
     var percentMode = x.options.percentMode;
     var percentage = (percentMode === "parent") ? d.percent : percentageTotal;
     var percentageString = percentage + "%";
@@ -246,6 +251,7 @@ function draw (el, instance, dispatch_) {
       percentageString = "< 0.1%";
     }
 
+    // if percent is of parent then the count will also be of parent
     var outerSize = (percentMode === "parent") ? d.parentSize : totalSize;
     var countString = [
         '<span style = "font-size:.7em">',
@@ -666,8 +672,6 @@ HTMLWidgets.widget({
           json = x.data;
         }
         instance.json = json;
-
-        console.log(json);
 
         draw(el, instance, dispatch_);
 

--- a/man/sunburst.Rd
+++ b/man/sunburst.Rd
@@ -5,11 +5,11 @@
 \title{`d3.js` Sequence Sunburst Diagrams}
 \usage{
 sunburst(data = NULL, legendOrder = NULL, colors = NULL,
-  valueField = "size", percent = TRUE, count = FALSE,
-  explanation = NULL, breadcrumb = list(), legend = list(),
-  sortFunction = NULL, sumNodes = TRUE, withD3 = FALSE, width = NULL,
-  height = NULL, elementId = NULL, sizingPolicy = NULL, csvdata = NULL,
-  jsondata = NULL)
+  valueField = "size", percent = TRUE, percentMode = c("total", "parent"),
+  count = FALSE, explanation = NULL, breadcrumb = list(),
+  legend = list(), sortFunction = NULL, sumNodes = TRUE, withD3 = FALSE,
+  width = NULL, height = NULL, elementId = NULL, sizingPolicy = NULL,
+  csvdata = NULL, jsondata = NULL)
 }
 \arguments{
 \item{data}{data in csv source,target form or in
@@ -33,6 +33,9 @@ a JavaScript \code{function}.}
 value is \code{"size"}.}
 
 \item{percent}{\code{logical} to include percentage of total in the explanation.}
+
+\item{percentMode}{\code{character} to determine if included percentage and count is of
+the total or the parent element.}
 
 \item{count}{\code{logical} to include count and total in the explanation.}
 


### PR DESCRIPTION
* Added argument `percentMode = c("total", "parent")` to allow percentages and counts to be shown relative to the parent element rather than of the total.
    * Breadcrumb will always show percentage relative to the total
    * Default argument value is `"total"`, so results of existing function calls should be unchanged

I'm not totally sure of the argument name, since it toggles both percent and count modes, but having a separate `percentMode` and `countMode` feels a bit clunky. Maybe can even incorporate this into the JS to toggle within the widget.

```
sequences <- read.csv(
  system.file("examples/visit-sequences.csv",package="sunburstR")
  ,header = FALSE
  ,stringsAsFactors = FALSE
)[1:100,]

```
## Displaying total percentage:
![sunburst_total](https://user-images.githubusercontent.com/6036662/42980229-d36d59b2-8c19-11e8-97e8-3afd7adceef9.png)

```
sunburst(
  sequences
  ,count = TRUE
)
```

## Displaying percentage of parent:
![sunburst_parent](https://user-images.githubusercontent.com/6036662/42980230-d6367da4-8c19-11e8-8ba9-5db25600fe74.png)

```
sunburst(
  sequences
  ,count = TRUE
  ,percentMode = "parent"
)
```