### PR TITLE
add an ORCID to an author

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Authors@R: c(
       person(
         "CJ", "Yetman"
         , role = c("ctb")
-        , comment = "R interface"
+        , comment = c("R interface", ORCID = "0000-0001-5099-9500")
         , email = "cj@cjyetman.com"
       )
     )


### PR DESCRIPTION
CRAN now supports ORCID's per https://cran.r-project.org/web/packages/submission_checklist.html
I'm not 100% sure how this works when there's an additional unnamed comment element ("R interface" in my case here). I searched for an existing example like that, but I couldn't find one.